### PR TITLE
Fix cases where a font family has multiple spaces in it

### DIFF
--- a/plugin/build/utils.js
+++ b/plugin/build/utils.js
@@ -9,7 +9,7 @@ exports.groupBy = groupBy;
 const promises_1 = __importDefault(require("fs/promises"));
 const path_1 = __importDefault(require("path"));
 function toAndroidResourceString(string) {
-    return string.replace(/(-| )/, '_').toLowerCase();
+    return string.replace(/(-| )/g, '_').toLowerCase();
 }
 async function resolveFontPaths(fonts, projectRoot) {
     const promises = fonts.map(async (p) => {

--- a/plugin/src/utils.ts
+++ b/plugin/src/utils.ts
@@ -2,7 +2,7 @@ import fs from 'fs/promises';
 import path from 'path';
 
 export function toAndroidResourceString(string: string) {
-  return string.replace(/(-| )/, '_').toLowerCase();
+  return string.replace(/(-| )/g, '_').toLowerCase();
 }
 
 export async function resolveFontPaths(fonts: string[], projectRoot: string) {

--- a/plugin/src/withFonts.ts
+++ b/plugin/src/withFonts.ts
@@ -27,12 +27,6 @@ const withFonts: ConfigPlugin<FontProps> = (config, props) => {
     return config;
   }
 
-  if (props.fonts.some((font) => font.family.includes(" "))) {
-    throw new Error(
-      "Font family names must not contain any spaces. Please remove spaces from the font family names in your configuration."
-    );
-  }
-
   config = withFontsIos(config, props.fonts ?? []);
   config = withFontsAndroid(config, props.fonts ?? []);
 

--- a/plugin/src/withFonts.ts
+++ b/plugin/src/withFonts.ts
@@ -27,6 +27,12 @@ const withFonts: ConfigPlugin<FontProps> = (config, props) => {
     return config;
   }
 
+  if (props.fonts.some((font) => font.family.includes(" "))) {
+    throw new Error(
+      "Font family names must not contain any spaces. Please remove spaces from the font family names in your configuration."
+    );
+  }
+
   config = withFontsIos(config, props.fonts ?? []);
   config = withFontsAndroid(config, props.fonts ?? []);
 


### PR DESCRIPTION
Usecase: If I setup a family name with multiple spaces in it, the xml name generated contained spaces, resulting in build failure on Android.